### PR TITLE
Run CI on Node 24 so npm ci accepts the npm 11 lockfile

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,10 +11,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      # Node 24 ships npm 11, which is what generates package-lock.json locally.
+      # On npm 10 (Node 20) `npm ci` rejects that lock: it wants to add
+      # postcss-load-config's optional peer `yaml@2`, which npm 11 omits.
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/nodejsdev.yml
+++ b/.github/workflows/nodejsdev.yml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      # Keep in sync with nodejs.yml — see the Node 24 / npm 11 note there.
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,11 @@ npm run build        # production build into build/
 npm test             # react-scripts test --env=jsdom
 ```
 
-Requires Node >= 18 (enforced via `engines`). CI uses Node 20.
+Requires Node >= 18 (enforced via `engines`). CI uses Node 24.
+
+`package-lock.json` is npm-11 shaped. Regenerating it under npm 10 adds an entry
+(`tailwindcss/node_modules/yaml`) that npm 11 strips again on the next `npm install`,
+and `npm ci` on npm 10 fails without it. Keep CI on a Node that ships npm 11.
 
 **There are no tests.** No `*.test.*` / `*.spec.*` / `__tests__` exist. `npm test` starts CRA's Jest watcher and finds nothing; under `CI=true` it exits non-zero, which is why no CI job runs it. Adding a test file is enough for CRA to pick it up — no config needed.
 


### PR DESCRIPTION
## Problem

The deploy on `master` ([run 29027537414](https://github.com/tdmiller1/tuckermiller.dev/actions/runs/29027537414/job/86151182578)) failed at `npm ci`, before the build ran:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: yaml@2.9.0 from lock file
```

`package-lock.json` is generated by npm 11 (bundled with Node 24). CI ran Node 20, which ships npm 10. The two disagree about a single package: `postcss-load-config` — pulled in via `tailwindcss`, itself a transitive dep of `react-scripts` — declares an **optional** peer dependency on `yaml@^2.4.2`. npm 10 requires that optional peer to be present in the lock; npm 11 omits it.

## Why not just regenerate the lock

Regenerating under npm 10 does produce a lock that both npm 10 and npm 11 accept. But it isn't durable: the added `tailwindcss/node_modules/yaml` entry is **stripped again** by the next `npm install` on npm 11, which silently re-breaks `npm ci` on CI.

Verified:

- `npm ci` passes on npm 11.12.1, fails with the identical error on npm 10.8.2.
- An npm-10-generated lock is accepted by both.
- `npm install` on npm 11 against that lock removes the entry; npm 10 then fails on it again.

So this PR aligns CI's npm with the npm that writes the lock, rather than fighting the lock.

## Changes

- `.github/workflows/nodejs.yml` — Node 20 → 24, with a comment explaining why
- `.github/workflows/nodejsdev.yml` — same, kept in sync
- `CLAUDE.md` — the "CI uses Node 20" line was now wrong; documented the lockfile constraint

## Testing

- `CI=true npm run build` passes on Node 24 locally (react-scripts 5 is fine there)
- Both workflow files still parse as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)