### PR TITLE
Deploy with a service account key instead of a CI token

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,10 +25,32 @@ jobs:
         run: npm run build
         env:
           CI: true
+      # Auth is a service account key, not `firebase login:ci`. Note that a
+      # FIREBASE_TOKEN in the environment SHADOWS the key (firebase-tools checks
+      # it first), so it must not be set on the deploy step.
+      - name: Write service account key
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT secret is empty or unset"
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-key.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-key.json" >> "$GITHUB_ENV"
+
       # Deploy runs exactly once. It previously sat inside a
       # `node-version: [10.x, 12.x]` matrix, so every push to master fired two
       # concurrent `firebase deploy` calls racing to publish the same commit.
+      #
+      # `firebase deploy` does NOT build; it uploads whatever is in build/.
       - name: Deploy to Firebase Hosting
-        run: npx --yes firebase-tools@13 deploy --only hosting --token "$FIREBASE_TOKEN"
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: >-
+          npx --yes firebase-tools@13 deploy
+          --only hosting
+          --project tuckermillerdev-8c74f
+          --non-interactive
+
+      - name: Remove service account key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-key.json"

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ node_modules/
 build
 # Local resume working notes — contains employer-internal detail, do not publish
 resume/claude-jira-github-analysis-3-year.md
+
+# Firebase / GCP service account keys — never commit these
+*-*.json.key
+*gserviceaccount*.json
+tuckermillerdev-*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,12 @@ Page components are still ES6 class components; the shell (`App`, `AppNavigation
 
 **The live site updates by pushing to `master`.** There is no deploy script to run locally.
 
-`.github/workflows/nodejs.yml` fires on push to `master`: `npm ci` → `npm run build` (with `CI=true`) → `npx firebase-tools deploy --only hosting` using the `FIREBASE_TOKEN` repo secret.
+`.github/workflows/nodejs.yml` fires on push to `master`: `npm ci` → `npm run build` (with `CI=true`) → `npx firebase-tools deploy --only hosting`, authenticating with the `FIREBASE_SERVICE_ACCOUNT` repo secret (a service account JSON key, written to a temp file that `GOOGLE_APPLICATION_CREDENTIALS` points at).
+
+Auth used to be the `FIREBASE_TOKEN` secret from `firebase login:ci`. That is deprecated and the token stopped authenticating. Two traps if you touch this:
+
+- **`FIREBASE_TOKEN` in the environment shadows the service account** — `requireAuth` checks it before falling back to Application Default Credentials. Don't set both.
+- **An auth failure does not look like an auth failure.** `deploy --only hosting` calls `requireHostingSite()`, whose catch block re-throws only on 403 or "no default site" and *swallows 401s*. The deploy then dies much later with `Assertion failed: resolving hosting target of a site with no site name or target name`. If you ever see that assertion, it means authentication failed — re-run with `--debug` to see the real 401.
 
 Deploying by hand is possible but differs from CI in a way that matters: **`firebase deploy` does not build.** Per `firebase.json` it uploads whatever is currently in `build/`. Always `npm run build` immediately before any manual deploy, and note `firebase-tools` is not a dependency — use `npx firebase-tools` or a global install plus `firebase login`.
 


### PR DESCRIPTION
## ⚠️ Do not merge until the `FIREBASE_SERVICE_ACCOUNT` secret exists

The workflow fails fast with a clear error if the secret is missing, but the deploy (and therefore the live site) stays broken until it's set. See setup steps below.

## Problem

Deploy on `master` failed with:

```
Error: Assertion failed: resolving hosting target of a site with no site name
or target name. This should have caused an error earlier
```

That message has nothing to do with hosting targets. Traced through firebase-tools:

1. `deploy --only hosting` runs a `before` hook that calls `requireHostingSite()` to resolve the site name (a network call to `getDefaultHostingSite`).
2. In `lib/commands/deploy.js`, the `catch` around it re-throws **only** on a 403 or `errNoDefaultSite`. Any other error — including a **401** — is silently swallowed.
3. `options.site` stays `undefined`, and `lib/hosting/config.js:resolveTargets()` later throws the assertion.

Reproduced locally, and `--debug` shows the swallowed error:

```
GET https://firebase.googleapis.com/v1beta1/projects/tuckermillerdev-8c74f 401
Error: Assertion failed: resolving hosting target of a site with no site name...
```

So the assertion means **authentication failed**. The project ID resolves fine from `.firebaserc`. The `FIREBASE_TOKEN` secret (from the deprecated `firebase login:ci`) no longer authenticates.

## Fix

Authenticate with a service account key via `GOOGLE_APPLICATION_CREDENTIALS`, which is what firebase-tools' own deprecation warning points to.

**Gotcha worth knowing:** `requireAuth` checks `FIREBASE_TOKEN` in the environment *before* falling back to Application Default Credentials (`lib/requireAuth.js:71`). If the token stays in the deploy step's `env:`, it shadows the service account and the failure persists. This PR removes it.

## Setup required before merging

Easiest path — this creates the service account, grants roles, and adds the repo secret for you:

```bash
npx firebase-tools@13 init hosting:github
```

Or manually:
1. GCP Console → IAM & Admin → Service Accounts → create one in project `tuckermillerdev-8c74f`.
2. Grant **Firebase Hosting Admin** (`roles/firebasehosting.admin`) and **Firebase Viewer** (`roles/firebase.viewer`) — the latter is needed for the `getFirebaseProject` call that resolves the site.
3. Create a JSON key.
4. Repo → Settings → Secrets and variables → Actions → new secret named `FIREBASE_SERVICE_ACCOUNT`, paste the **entire JSON file contents**.
5. Delete the now-dead `FIREBASE_TOKEN` secret.

## Notes

- `--token` is *not* yet removed — it still works (with a warning) in firebase-tools 13, 14, and 15. The warning was a clue, not the cause. The cause is that this particular token is dead.
- Added `--project tuckermillerdev-8c74f` and `--non-interactive` so the deploy fails loudly rather than hanging or guessing.
- The key is written to `$RUNNER_TEMP` and removed in an `if: always()` step.
- Documented both traps in `CLAUDE.md` so the next confusing assertion is a one-line lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)